### PR TITLE
[FEAT] chatGPT 답변 생성 시 db에 답변 저장하는 로직 구현

### DIFF
--- a/src/main/java/com/talkpossible/project/domain/controller/ChatController.java
+++ b/src/main/java/com/talkpossible/project/domain/controller/ChatController.java
@@ -21,8 +21,11 @@ public class ChatController {
     private final ChatStreamService chatStreamService;
 
     @PostMapping("/chatGPT/remember")
-    public ResponseEntity<ChatResponse> getquestions(@RequestBody UserChatRequest userChatRequest) {
-        return ResponseEntity.ok(chatRememberService.getGPTAnswer(userChatRequest));
+    public ResponseEntity<ChatResponse> getquestions(
+            @RequestBody UserChatRequest userChatRequest,
+            @RequestHeader long simulationId
+    ) {
+        return ResponseEntity.ok(chatRememberService.getGPTAnswer(userChatRequest, simulationId));
     }
 
     @PostMapping(value = "/chatGPT/streaming", produces = MediaType.TEXT_EVENT_STREAM_VALUE)

--- a/src/main/java/com/talkpossible/project/domain/domain/Conversation.java
+++ b/src/main/java/com/talkpossible/project/domain/domain/Conversation.java
@@ -24,7 +24,7 @@ public class Conversation extends BaseTimeEntity {
     private Simulation simulation;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "sender_id", nullable = false)
+    @JoinColumn(name = "sender_id")
     private Patient patient;
 
     @Column(name = "TEXT", nullable = false)
@@ -40,12 +40,12 @@ public class Conversation extends BaseTimeEntity {
         this.sendTime = sendTime;
     }
 
-    public static Conversation create(Simulation simulation, Patient patient, String content, LocalDateTime sendTime) {
+    public static Conversation create(Simulation simulation, Patient patient, String content, String sendTime) {
         return Conversation.builder()
                 .simulation(simulation)
                 .patient(patient)
                 .content(content)
-                .sendTime(sendTime)
+                .sendTime(LocalDateTime.parse(sendTime))
                 .build();
     }
 }

--- a/src/main/java/com/talkpossible/project/domain/dto/chat/request/UserChatRequest.java
+++ b/src/main/java/com/talkpossible/project/domain/dto/chat/request/UserChatRequest.java
@@ -3,7 +3,8 @@ package com.talkpossible.project.domain.dto.chat.request;
 public record UserChatRequest(
         String cacheId,
 
-        String message
+        String message,
+        String sendTime
 
 ) {
 }

--- a/src/main/java/com/talkpossible/project/domain/repository/ConversationRepository.java
+++ b/src/main/java/com/talkpossible/project/domain/repository/ConversationRepository.java
@@ -1,0 +1,7 @@
+package com.talkpossible.project.domain.repository;
+
+import com.talkpossible.project.domain.domain.Conversation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConversationRepository extends JpaRepository<Conversation, Long> {
+}


### PR DESCRIPTION
# 📄 Work Description
- chatGPT 답변 생성 시 db에 답변 저장하는 로직 구현


# ⚙️ ISSUE
- closed #17 


# 📷 Screenshot
![스크린샷 2024-08-17 오후 7 38 45](https://github.com/user-attachments/assets/93d2bf1f-0b33-480a-988d-1e8a226478ff)
<img width="809" alt="image" src="https://github.com/user-attachments/assets/2547d350-d686-40c1-87a4-0e56ba6f082b">




# 💬 To Reviewers
1. conversation 저장시 sender_id(patient)를 null로 저장하도록 했습니다! (chatGPT의 대화 내용이므로) 따라서 원래 필드가 nullable=false였던걸 없앴습니다!
```java
    @ManyToOne(fetch = LAZY)
    @JoinColumn(name = "sender_id")
    private Patient patient;
```
```java
        Message GptMessage = response.getChoices().get(0).getMessage();

        conversationRepository.save(Conversation.create(
                getSimulation(simulationId), null,
                GptMessage.getContent(), userChatRequest.sendTime()
        ));
```


# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
