### PR TITLE
[FIX] gpt 대화 내용 저장시 sendTime request에서 제외

### DIFF
--- a/src/main/java/com/talkpossible/project/domain/domain/Conversation.java
+++ b/src/main/java/com/talkpossible/project/domain/domain/Conversation.java
@@ -40,12 +40,12 @@ public class Conversation extends BaseTimeEntity {
         this.sendTime = sendTime;
     }
 
-    public static Conversation create(Simulation simulation, Patient patient, String content, String sendTime) {
+    public static Conversation create(Simulation simulation, Patient patient, String content, LocalDateTime sendTime) {
         return Conversation.builder()
                 .simulation(simulation)
                 .patient(patient)
                 .content(content)
-                .sendTime(LocalDateTime.parse(sendTime))
+                .sendTime(sendTime)
                 .build();
     }
 }

--- a/src/main/java/com/talkpossible/project/domain/dto/chat/request/UserChatRequest.java
+++ b/src/main/java/com/talkpossible/project/domain/dto/chat/request/UserChatRequest.java
@@ -3,8 +3,6 @@ package com.talkpossible.project.domain.dto.chat.request;
 public record UserChatRequest(
         String cacheId,
 
-        String message,
-        String sendTime
-
+        String message
 ) {
 }

--- a/src/main/java/com/talkpossible/project/domain/service/ChatRememberService.java
+++ b/src/main/java/com/talkpossible/project/domain/service/ChatRememberService.java
@@ -20,6 +20,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import jakarta.annotation.PostConstruct;
+
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Service
@@ -109,7 +111,7 @@ public class ChatRememberService {
 
         conversationRepository.save(Conversation.create(
                 getSimulation(simulationId), null,
-                GptMessage.getContent(), userChatRequest.sendTime()
+                GptMessage.getContent(), LocalDateTime.now()
         ));
 
         history.add(new Message("system", GptMessage.getContent()));


### PR DESCRIPTION
# 📄 Work Description
- gpt 대화 내용 저장시 sendTime request에서 제외

# ⚙️ ISSUE
- closed #17 


# 📷 Screenshot
 - 동영상, 사진, 로그 등등
 - ex) 큐알 성공 이미지, 스웨거, 포스트맨 등


# 💬 To Reviewers
수정사항이 있어서 올립니다! 저번 PR에 커밋을 반영하고 merge를 한다는게,, 

# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
