### PR TITLE
[FEAT] 환자목록 조회 API

### DIFF
--- a/src/main/java/com/talkpossible/project/domain/controller/MyPageController.java
+++ b/src/main/java/com/talkpossible/project/domain/controller/MyPageController.java
@@ -1,0 +1,24 @@
+package com.talkpossible.project.domain.controller;
+
+import com.talkpossible.project.domain.dto.patient.reponse.PatientListResponse;
+import com.talkpossible.project.domain.service.MyPageService;
+import com.talkpossible.project.global.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping("/mypage/patients")
+    public ResponseEntity<PatientListResponse> getPatientList() {
+       return ResponseEntity.ok(myPageService.getPatientList(jwtTokenProvider.getDoctorId()));
+    }
+}

--- a/src/main/java/com/talkpossible/project/domain/domain/MotionDetail.java
+++ b/src/main/java/com/talkpossible/project/domain/domain/MotionDetail.java
@@ -27,8 +27,6 @@ public class MotionDetail extends BaseTimeEntity {
 
     private String timestamp;
 
-    private String videoUrl;
-
     @Builder
     private MotionDetail(
             Simulation simulation, String situationDate,
@@ -37,7 +35,6 @@ public class MotionDetail extends BaseTimeEntity {
         this.simulation = simulation;
         this.motionName = motionName;
         this.timestamp = timestamp;
-        this.videoUrl = videoUrl;
     }
 
     public static MotionDetail of(final Simulation simulation,

--- a/src/main/java/com/talkpossible/project/domain/domain/Simulation.java
+++ b/src/main/java/com/talkpossible/project/domain/domain/Simulation.java
@@ -39,11 +39,16 @@ public class Simulation extends BaseTimeEntity {
 
     private Boolean isStutter;
 
+    private String videoUrl;
+
     public void updateRunDateAndTotalTime(
-            final String runDate, final String totalTime
+            final String runDate,
+            final String totalTime,
+            final String videoUrl
     ) {
         this.runDate = LocalDate.parse(runDate);
         this.totalTime = Time.valueOf(totalTime);
+        this.videoUrl = videoUrl;
     }
 
 }

--- a/src/main/java/com/talkpossible/project/domain/dto/patient/reponse/PatientDetailResponse.java
+++ b/src/main/java/com/talkpossible/project/domain/dto/patient/reponse/PatientDetailResponse.java
@@ -1,0 +1,21 @@
+package com.talkpossible.project.domain.dto.patient.reponse;
+
+import com.talkpossible.project.domain.domain.Patient;
+import lombok.Builder;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+public record PatientDetailResponse(
+        long patientId,
+        String name,
+        String birth
+) {
+    public static PatientDetailResponse of(final Patient patient) {
+        return PatientDetailResponse.builder()
+                .patientId(patient.getId())
+                .name(patient.getName())
+                .birth(String.valueOf(patient.getBirthday()))
+                .build();
+    }
+}

--- a/src/main/java/com/talkpossible/project/domain/dto/patient/reponse/PatientListResponse.java
+++ b/src/main/java/com/talkpossible/project/domain/dto/patient/reponse/PatientListResponse.java
@@ -1,0 +1,13 @@
+package com.talkpossible.project.domain.dto.patient.reponse;
+
+import com.talkpossible.project.domain.domain.Patient;
+
+import java.util.List;
+
+public record PatientListResponse(
+        List<PatientDetailResponse> patients
+) {
+    public static PatientListResponse of(final List<Patient> patientList) {
+        return new PatientListResponse(patientList.stream().map(PatientDetailResponse::of).toList());
+    }
+}

--- a/src/main/java/com/talkpossible/project/domain/repository/PatientRepository.java
+++ b/src/main/java/com/talkpossible/project/domain/repository/PatientRepository.java
@@ -3,5 +3,9 @@ package com.talkpossible.project.domain.repository;
 import com.talkpossible.project.domain.domain.Patient;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PatientRepository extends JpaRepository<Patient, Long> {
+
+    List<Patient> findAllBydoctorId(long doctorId);
 }

--- a/src/main/java/com/talkpossible/project/domain/service/MotionService.java
+++ b/src/main/java/com/talkpossible/project/domain/service/MotionService.java
@@ -33,7 +33,11 @@ public class MotionService {
         Patient patient = patientRepository.findById(userMotionRequest.patientId())
                 .orElseThrow(() -> new IllegalArgumentException("id에 해당하는 환자 정보를 찾을 수 없습니다."));
 
-        simulation.updateRunDateAndTotalTime(userMotionRequest.runDate(), userMotionRequest.totalTime());
+        simulation.updateRunDateAndTotalTime(
+                userMotionRequest.runDate(),
+                userMotionRequest.totalTime(),
+                userMotionRequest.videoUrl()
+        );
 
         motionDetailRepository.saveAll(motionDetails);
     }

--- a/src/main/java/com/talkpossible/project/domain/service/MyPageService.java
+++ b/src/main/java/com/talkpossible/project/domain/service/MyPageService.java
@@ -1,0 +1,22 @@
+package com.talkpossible.project.domain.service;
+
+import com.talkpossible.project.domain.domain.Patient;
+import com.talkpossible.project.domain.dto.patient.reponse.PatientListResponse;
+import com.talkpossible.project.domain.repository.PatientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageService {
+
+    private final PatientRepository patientRepository;
+
+    public PatientListResponse getPatientList(final long doctorId) {
+        return PatientListResponse.of(patientRepository.findAllBydoctorId(doctorId));
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
- 환자목록 조회 API

# ⚙️ ISSUE
- closed #30 


# 📷 Screenshot
 - postman 화면
<img width="1318" alt="스크린샷 2024-08-20 오후 12 56 56" src="https://github.com/user-attachments/assets/03229f72-7e9b-42d9-896c-65072b61740c">


# 💬 To Reviewers
따로 크게 로직이 어려운 부분이 없었어서 전달드릴 사항은 없습니다!!
아!! 그 videoUrl은 motionDetail이 아닌, simulation에 저장되도록  수정했습니다!
```java
simulation.updateRunDateAndTotalTime(
        userMotionRequest.runDate(),
        userMotionRequest.totalTime(),
        userMotionRequest.videoUrl()
);
```

# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
