### PR TITLE
[FEAT] 사용자 프로필 조회 로직 구현

### DIFF
--- a/src/main/java/com/talkpossible/project/domain/controller/DoctorController.java
+++ b/src/main/java/com/talkpossible/project/domain/controller/DoctorController.java
@@ -3,6 +3,7 @@ package com.talkpossible.project.domain.controller;
 import com.talkpossible.project.domain.dto.doctor.request.LoginRequest;
 import com.talkpossible.project.domain.dto.doctor.response.LoginResponse;
 import com.talkpossible.project.domain.dto.doctor.request.SignupRequest;
+import com.talkpossible.project.domain.dto.doctor.response.ProfileResponse;
 import com.talkpossible.project.domain.service.DoctorService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,23 +12,30 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1/")
 public class DoctorController {
 
     private final DoctorService doctorService;
 
     // 회원가입
-    @PostMapping("/signup")
+    @PostMapping("/auth/signup")
     public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest signupRequest){
         doctorService.signup(signupRequest);
         return ResponseEntity.ok().build();
     }
 
     // 로그인
-    @PostMapping("/login")
+    @PostMapping("/auth/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest){
         return ResponseEntity.ok(doctorService.login(loginRequest));
     }
+
+    // 사용자 프로필 조회
+    @GetMapping("/profile")
+    public ResponseEntity<ProfileResponse> getProfile(){
+        return ResponseEntity.ok(doctorService.getProfile());
+    }
+
 
     // (테스트용) 인증이 필수인 URL 요청
     @GetMapping("/login-required-test")

--- a/src/main/java/com/talkpossible/project/domain/domain/Doctor.java
+++ b/src/main/java/com/talkpossible/project/domain/domain/Doctor.java
@@ -36,6 +36,8 @@ public class Doctor extends BaseTimeEntity {
 
     private String phoneNum;
 
+    private String profileImgUrl;
+
     @Enumerated(EnumType.STRING)
     private Role role;
 
@@ -43,10 +45,12 @@ public class Doctor extends BaseTimeEntity {
 
     @Builder
     private Doctor(String name, String email, String password,
-                   String phoneNum, Role role, String refreshToken) {
+                   String profileImgUrl, String phoneNum,
+                   Role role, String refreshToken) {
         this.name = name;
         this.email = email;
         this.password = password;
+        this.profileImgUrl = profileImgUrl;
         this.phoneNum = phoneNum;
         this.role = role;
         this.refreshToken = refreshToken;
@@ -57,6 +61,7 @@ public class Doctor extends BaseTimeEntity {
                 .name(request.getName())
                 .email(request.getEmail())
                 .password(encryptedPassword)
+                //.profileImgUrl(profileImgUrl)
                 .phoneNum(request.getPhoneNum())
                 .role(role)
                 .refreshToken(null)

--- a/src/main/java/com/talkpossible/project/domain/dto/doctor/response/ProfileResponse.java
+++ b/src/main/java/com/talkpossible/project/domain/dto/doctor/response/ProfileResponse.java
@@ -1,0 +1,20 @@
+package com.talkpossible.project.domain.dto.doctor.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProfileResponse {
+
+    private String profileImgUrl;
+    private String name;
+
+    public static ProfileResponse from(String profileImgUrl, String name){
+        return ProfileResponse.builder()
+                .profileImgUrl(profileImgUrl)
+                .name(name)
+                .build();
+    }
+
+}

--- a/src/main/java/com/talkpossible/project/domain/service/DoctorService.java
+++ b/src/main/java/com/talkpossible/project/domain/service/DoctorService.java
@@ -4,6 +4,7 @@ import com.talkpossible.project.domain.domain.Doctor;
 import com.talkpossible.project.domain.dto.doctor.request.LoginRequest;
 import com.talkpossible.project.domain.dto.doctor.response.LoginResponse;
 import com.talkpossible.project.domain.dto.doctor.request.SignupRequest;
+import com.talkpossible.project.domain.dto.doctor.response.ProfileResponse;
 import com.talkpossible.project.global.security.jwt.JwtTokenProvider;
 import com.talkpossible.project.domain.repository.DoctorRepository;
 import com.talkpossible.project.global.enumType.Role;
@@ -59,6 +60,15 @@ public class DoctorService {
         // TODO refresh token 업데이트
 
         return new LoginResponse(accessToken, refreshToken);
+    }
+
+    // 사용자 프로필 조회
+    public ProfileResponse getProfile() {
+
+        Doctor doctor = doctorRepository.findById(jwtTokenProvider.getDoctorId())
+                .orElseThrow(() -> new CustomException(DOCTOR_NOT_FOUND));
+
+        return ProfileResponse.from(doctor.getProfileImgUrl(), doctor.getName());
     }
 
 }


### PR DESCRIPTION
# 📄 Work Description
- 사용자 프로필 조회 로직 구현

# ⚙️ ISSUE
- closed #21 

# 📷 Screenshot
<!-- - 동영상, 사진, 로그 등등 -->
<!-- - ex) 큐알 성공 이미지, 스웨거, 포스트맨 등 -->
![image](https://github.com/user-attachments/assets/110c3c61-c564-4e90-9abf-b9c02101025f)

# 💬 To Reviewers
<!-- 리뷰어들에게 하고 싶은 말 -->
- Doctor 테이블에 프로필 이미지 컬럼 (profileImgUrl) 추가했습니다.

<!-- # 🔗 Reference -->
<!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크) -->
