### PR TITLE
[FEAT] 피드백 조회 로직 구현 (대화 내용)

### DIFF
--- a/src/main/java/com/talkpossible/project/domain/controller/ConversationController.java
+++ b/src/main/java/com/talkpossible/project/domain/controller/ConversationController.java
@@ -1,0 +1,25 @@
+package com.talkpossible.project.domain.controller;
+
+import com.talkpossible.project.domain.dto.conversation.response.ConversationResponse;
+import com.talkpossible.project.domain.service.ConversationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ConversationController {
+
+    private final ConversationService conversationService;
+
+    // 피드백 조회 - 대화 내용
+    @GetMapping("/simulations/{simulationId}/conversation")
+    public ResponseEntity<ConversationResponse> getConversationFeedback(@PathVariable long simulationId){
+        return ResponseEntity.ok(conversationService.getConversationFeedback(simulationId));
+    }
+
+}

--- a/src/main/java/com/talkpossible/project/domain/domain/Conversation.java
+++ b/src/main/java/com/talkpossible/project/domain/domain/Conversation.java
@@ -27,7 +27,7 @@ public class Conversation extends BaseTimeEntity {
     @JoinColumn(name = "sender_id")
     private Patient patient;
 
-    @Column(name = "TEXT", nullable = false)
+    @Column(nullable = false)
     private String content;
 
     private LocalDateTime sendTime;

--- a/src/main/java/com/talkpossible/project/domain/dto/conversation/response/ConversationResponse.java
+++ b/src/main/java/com/talkpossible/project/domain/dto/conversation/response/ConversationResponse.java
@@ -1,0 +1,35 @@
+package com.talkpossible.project.domain.dto.conversation.response;
+
+import com.talkpossible.project.domain.domain.Conversation;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ConversationResponse {
+
+    private List<Message> conversationList;
+
+    public static ConversationResponse from(List<Message> messageList){
+        return ConversationResponse.builder()
+                .conversationList(messageList)
+                .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Message {
+        String speaker;
+        String content;
+
+        public static Message from(Conversation conversation){
+            return Message.builder()
+                    .speaker(conversation.getPatient() == null ? "chatgpt" : "patient")
+                    .content(conversation.getContent())
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/com/talkpossible/project/domain/repository/ConversationRepository.java
+++ b/src/main/java/com/talkpossible/project/domain/repository/ConversationRepository.java
@@ -3,5 +3,10 @@ package com.talkpossible.project.domain.repository;
 import com.talkpossible.project.domain.domain.Conversation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ConversationRepository extends JpaRepository<Conversation, Long> {
+
+    List<Conversation> findBySimulationIdOrderBySendTimeAsc(long simulationId);
+
 }

--- a/src/main/java/com/talkpossible/project/domain/service/ConversationService.java
+++ b/src/main/java/com/talkpossible/project/domain/service/ConversationService.java
@@ -1,0 +1,51 @@
+package com.talkpossible.project.domain.service;
+
+import com.talkpossible.project.domain.domain.Simulation;
+import com.talkpossible.project.domain.dto.conversation.response.ConversationResponse;
+import com.talkpossible.project.domain.repository.ConversationRepository;
+import com.talkpossible.project.domain.repository.SimulationRepository;
+import com.talkpossible.project.global.exception.CustomException;
+import com.talkpossible.project.global.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.talkpossible.project.global.exception.CustomErrorCode.ACCESS_DENIED;
+import static com.talkpossible.project.global.exception.CustomErrorCode.SIMULATION_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class ConversationService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ConversationRepository conversationRepository;
+    private final SimulationRepository simulationRepository;
+
+    // 피드백 조회 - 대화 내용
+    public ConversationResponse getConversationFeedback(long simulationId) {
+
+        // 권한 확인
+        Long doctorId = jwtTokenProvider.getDoctorId();
+        Simulation simulation = getSimulation(simulationId);
+
+        if(doctorId != simulation.getPatient().getDoctor().getId()){
+            throw new CustomException(ACCESS_DENIED);
+        }
+
+        // 대화 내역 조회
+        List<ConversationResponse.Message> messageList =
+                conversationRepository.findBySimulationIdOrderBySendTimeAsc(simulationId)
+                    .stream()
+                    .map(ConversationResponse.Message::from)
+                    .collect(Collectors.toList());
+
+        return ConversationResponse.from(messageList);
+    }
+
+    private Simulation getSimulation(final long simulationId) {
+        return simulationRepository.findById(simulationId)
+                .orElseThrow(() -> new CustomException(SIMULATION_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
# 📄 Work Description
- 피드백 조회 로직 구현 (대화 내용)

# ⚙️ ISSUE
closed #29 

# 📷 Screenshot
 <!-- - 동영상, 사진, 로그 등등 -->
 <!-- - ex) 큐알 성공 이미지, 스웨거, 포스트맨 등 -->
![image](https://github.com/user-attachments/assets/f3b4dcdf-203b-4d1e-abab-7080c4e2b326)

# 💬 To Reviewers
<!-- 리뷰어들에게 하고 싶은 말 -->
* 대화 시 말한 주체(speaker)는 conversation의 patient 값의 null 여부로 판단하도록 구현했습니다.
```java    
    public static Message from(Conversation conversation){
         return Message.builder()
              .speaker(conversation.getPatient() == null ? "chatgpt" : "patient")
              ...
    }
```

* Conversation 엔티티의 content 필드에 '컬럼명'이 TEXT로 매핑되도록 되어있어서 해당 옵션은 삭제했습니다.
```java
    @Column(name = "TEXT", nullable = false)
    private String content;
```

 <!-- # 🔗 Reference -->
 <!-- 문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크) -->
