### PR TITLE
[FEAT] 피드백 조회 로직 수정 (시뮬레이션 정보 & 영상)

### DIFF
--- a/src/main/java/com/talkpossible/project/domain/dto/simulation/response/BasicInfoResponse.java
+++ b/src/main/java/com/talkpossible/project/domain/dto/simulation/response/BasicInfoResponse.java
@@ -19,10 +19,10 @@ public class BasicInfoResponse {
     private Body body;
     private Header header;
 
-    public static BasicInfoResponse from(Simulation simulation, Patient patient){
+    public static BasicInfoResponse from(Simulation simulation, Patient patient, long motionCount){
         return BasicInfoResponse.builder()
                 .header(Header.create(patient))
-                .body(Body.create(simulation, patient))
+                .body(Body.create(simulation, patient, motionCount))
                 .build();
     }
 
@@ -51,8 +51,9 @@ public class BasicInfoResponse {
         private String totalTime;
         private Integer wordsPerMin;
         private String videoUrl;
+        private int motionCount;
 
-        public static Body create(Simulation simulation, Patient patient){
+        public static Body create(Simulation simulation, Patient patient, long motionCount){
             return Body.builder()
                     .patientName(patient.getName())
                     .runDate(formatDate(simulation.getRunDate()))
@@ -60,6 +61,7 @@ public class BasicInfoResponse {
                     .totalTime(formatTime(simulation.getTotalTime()))
                     .wordsPerMin(simulation.getWordsPerMin())
                     .videoUrl(simulation.getVideoUrl())
+                    .motionCount((int) motionCount)
                     .build();
         }
 

--- a/src/main/java/com/talkpossible/project/domain/repository/MotionDetailRepository.java
+++ b/src/main/java/com/talkpossible/project/domain/repository/MotionDetailRepository.java
@@ -8,4 +8,7 @@ import java.util.List;
 public interface MotionDetailRepository extends JpaRepository<MotionDetail, Long> {
 
     List<MotionDetail> findAllBySimulationId(long simulationId);
+
+    long countBySimulationId(long simulationId);
+
 }

--- a/src/main/java/com/talkpossible/project/domain/service/SimulationService.java
+++ b/src/main/java/com/talkpossible/project/domain/service/SimulationService.java
@@ -89,7 +89,10 @@ public class SimulationService {
             throw new CustomException(ACCESS_DENIED);
         }
 
-        return BasicInfoResponse.from(simulation, simulation.getPatient());
+        // 동작 감지 횟수 조회
+        long motionCount = motionDetailRepository.countBySimulationId(simulationId);
+
+        return BasicInfoResponse.from(simulation, simulation.getPatient(), motionCount);
     }
 
     public UserMotionListResponse getMotionFeedback(final long simulationId) {


### PR DESCRIPTION
# 📄 Work Description
- 피드백 조회 (시뮬레이션 정보 & 영상)  시, 동작 감지 횟수(motionCount)도 응답하도록 response dto 수정

# ⚙️ ISSUE
- closed #46 

# 📷 Screenshot
 - 동영상, 사진, 로그 등등
 - ex) 큐알 성공 이미지, 스웨거, 포스트맨 등


# 💬 To Reviewers
- 프론트엔드의 요청에 따라, 피드백 조회 (시뮬레이션 정보 & 영상) response dto에 동작 감지 횟수(motionCount) 항목을 추가했습니다!
```java
        public static Body create(Simulation simulation, Patient patient, long motionCount){
            return Body.builder()
                    .patientName(patient.getName())
                    .runDate(formatDate(simulation.getRunDate()))
                    .situation(simulation.getSituation().getTitle())
                    .totalTime(formatTime(simulation.getTotalTime()))
                    .wordsPerMin(simulation.getWordsPerMin())
                    .videoUrl(simulation.getVideoUrl())
                    .motionCount((int) motionCount)
                    .build();
        }
```
