### PR TITLE
[FEAT] Flask 기반 음성 분석 관련 스크립트 호출 로직 구현

### DIFF
--- a/src/main/java/com/talkpossible/project/domain/controller/SimulationController.java
+++ b/src/main/java/com/talkpossible/project/domain/controller/SimulationController.java
@@ -6,8 +6,10 @@ import com.talkpossible.project.domain.dto.simulation.response.BasicInfoResponse
 import com.talkpossible.project.domain.dto.simulation.response.PatientSimulationDetailResponse;
 import com.talkpossible.project.domain.dto.simulation.response.PatientSimulationListResponse;
 import com.talkpossible.project.domain.dto.simulation.response.UserSimulationResponse;
+import com.talkpossible.project.domain.dto.speechrate.request.SpeechRateRequest;
 import com.talkpossible.project.domain.service.SimulationService;
 
+import com.talkpossible.project.domain.service.StutterDetailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class SimulationController {
 
     private final SimulationService simulationService;
+    private final StutterDetailService stutterDetailService;
 
     // 시뮬레이션 생성
     @PostMapping("/simulations")
@@ -40,6 +43,9 @@ public class SimulationController {
             @RequestBody UpdateSimulationRequest request
     ) {
         simulationService.addConversation(patientId, simulationId, request);
+
+        // 말더듬 분석
+        stutterDetailService.saveStutterDetail(simulationId, request.getVName());
 
         // 200 OK 상태 코드를 반환
         return ResponseEntity.ok().build();
@@ -71,5 +77,13 @@ public class SimulationController {
         return ResponseEntity.ok(simulationService.getPatientSimulationInfo(patientId));
     }
 
+    // 시뮬레이션 종료 후, 발화 속도 측정
+    @PostMapping("/simulations/{simulationId}/speech-rate")
+    public ResponseEntity<Void> addSpeechRate(@PathVariable long simulationId, @RequestBody SpeechRateRequest speechRateRequest) {
+
+        simulationService.saveSpeechRate(simulationId, speechRateRequest);
+
+        return ResponseEntity.ok().build();
+    }
 
 }

--- a/src/main/java/com/talkpossible/project/domain/domain/StutterDetail.java
+++ b/src/main/java/com/talkpossible/project/domain/domain/StutterDetail.java
@@ -1,8 +1,10 @@
 package com.talkpossible.project.domain.domain;
 
 import com.talkpossible.project.domain.domain.common.BaseTimeEntity;
+import com.talkpossible.project.domain.dto.stutter.response.StutterDetailResponse;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,6 +32,23 @@ public class StutterDetail extends BaseTimeEntity {
     private String audioUrl;
 
     @Column(nullable = false)
-    private String words;
+    private String words; // 말 더듬은 어절
+
+    @Builder
+    private StutterDetail (Simulation simulation,
+                           String imageUrl, String audioUrl, String words) {
+        this.simulation = simulation;
+        this.imageUrl = imageUrl;
+        this.audioUrl = audioUrl;
+        this.words = words;
+    }
+
+    public static StutterDetail create(Simulation simulation, StutterDetailResponse detailResponse) {
+        return StutterDetail.builder()
+                .imageUrl(detailResponse.getImageUrl())
+                .audioUrl(detailResponse.getAudioUrl())
+                .words(detailResponse.getWords())
+                .build();
+    }
 
 }

--- a/src/main/java/com/talkpossible/project/domain/dto/simulation/request/UpdateSimulationRequest.java
+++ b/src/main/java/com/talkpossible/project/domain/dto/simulation/request/UpdateSimulationRequest.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UpdateSimulationRequest {
     private String content;
+    private String vName;
 }

--- a/src/main/java/com/talkpossible/project/domain/dto/speechrate/request/SpeechRateRequest.java
+++ b/src/main/java/com/talkpossible/project/domain/dto/speechrate/request/SpeechRateRequest.java
@@ -1,0 +1,10 @@
+package com.talkpossible.project.domain.dto.speechrate.request;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SpeechRateRequest {
+    private List<String> audioFileNameList;
+}

--- a/src/main/java/com/talkpossible/project/domain/dto/stutter/response/StutterDetailResponse.java
+++ b/src/main/java/com/talkpossible/project/domain/dto/stutter/response/StutterDetailResponse.java
@@ -1,12 +1,18 @@
 package com.talkpossible.project.domain.dto.stutter.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class StutterDetailResponse {
-    private String audioUrl;
-    private String word;
+
+    @JsonProperty("image_url")
     private String imageUrl;
+
+    @JsonProperty("audio_url")
+    private String audioUrl;
+
+    private String words;
 }

--- a/src/main/java/com/talkpossible/project/domain/service/SimulationService.java
+++ b/src/main/java/com/talkpossible/project/domain/service/SimulationService.java
@@ -9,21 +9,31 @@ import com.talkpossible.project.domain.dto.simulation.response.BasicInfoResponse
 import com.talkpossible.project.domain.dto.simulation.response.PatientSimulationDetailResponse;
 import com.talkpossible.project.domain.dto.simulation.response.PatientSimulationListResponse;
 import com.talkpossible.project.domain.dto.simulation.response.UserSimulationResponse;
+import com.talkpossible.project.domain.dto.speechrate.request.SpeechRateRequest;
 import com.talkpossible.project.domain.repository.*;
 import com.talkpossible.project.domain.dto.simulation.request.UpdateSimulationRequest;
 import com.talkpossible.project.global.exception.CustomErrorCode;
 import com.talkpossible.project.global.exception.CustomException;
 import com.talkpossible.project.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.talkpossible.project.global.exception.CustomErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SimulationService {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -33,6 +43,8 @@ public class SimulationService {
     private final MotionDetailRepository motionDetailRepository;
     private final ConversationRepository conversationRepository;
     private final StutterDetailRepository stutterDetailRepository;
+
+    private final WebClient webClient;
 
 
     @Transactional
@@ -134,6 +146,43 @@ public class SimulationService {
     private Patient getPatient(final long patientId) {
         return patientRepository.findById(patientId)
                 .orElseThrow(() -> new CustomException(PATIENT_NOT_FOUND));
+    }
+
+    // 발화속도 저장
+    public void saveSpeechRate(long simulationId, SpeechRateRequest speechRateRequest) {
+
+        // 권한 확인
+        Long doctorId = jwtTokenProvider.getDoctorId();
+        Simulation simulation = getSimulation(simulationId);
+        if(doctorId != simulation.getPatient().getDoctor().getId()) {
+            throw new CustomException(ACCESS_DENIED);
+        }
+
+        // 발화속도 측정 요청
+        Map<String, List<String>> requestBody = new HashMap<>();
+        requestBody.put("file_names", speechRateRequest.getAudioFileNameList());
+
+        float wordsPerMin = webClient.post()
+                .uri("/speed_model")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .retrieve()
+
+                // 예외 처리
+                .onStatus(status -> status.is4xxClientError(), response -> {
+                    return Mono.error(new CustomException(SPEECH_RATE_CLIENT_ERROR));
+                })
+                .onStatus(status -> status.is5xxServerError(), response -> {
+                    return Mono.error(new CustomException(SPEECH_RATE_SERVER_ERROR));
+                })
+
+                // 정상 응답된 경우
+                .bodyToMono(Float.class)
+                .block();
+        log.info("*** 발화속도 측정 결과: {}", wordsPerMin); // EX) 88.79
+
+        // TODO 응답값 저장 (Float이 반환되므로 Simulation 엔티티 wordsPerMin 필드 타입 변경 필요!)
+
     }
 
 }

--- a/src/main/java/com/talkpossible/project/domain/service/StutterDetailService.java
+++ b/src/main/java/com/talkpossible/project/domain/service/StutterDetailService.java
@@ -2,6 +2,7 @@ package com.talkpossible.project.domain.service;
 
 import com.talkpossible.project.domain.domain.Simulation;
 import com.talkpossible.project.domain.domain.StutterDetail;
+import com.talkpossible.project.domain.dto.simulation.request.UpdateSimulationRequest;
 import com.talkpossible.project.domain.dto.stutter.response.StutterDetailResponse;
 import com.talkpossible.project.domain.repository.SimulationRepository;
 import com.talkpossible.project.domain.repository.StutterDetailRepository;
@@ -9,19 +10,30 @@ import com.talkpossible.project.global.exception.CustomErrorCode;
 import com.talkpossible.project.global.exception.CustomException;
 import com.talkpossible.project.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+
+import static com.talkpossible.project.global.exception.CustomErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StutterDetailService {
 
     private final SimulationRepository simulationRepository;
     private final StutterDetailRepository stutterDetailRepository;
     private final JwtTokenProvider jwtTokenProvider;  // JwtTokenProvider 추가
+    private final WebClient webClient;
 
     @Transactional(readOnly = true)
     public List<StutterDetailResponse> getStutterDetails(Long simulationId) {
@@ -51,4 +63,44 @@ public class StutterDetailService {
         return simulationRepository.findById(simulationId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.SIMULATION_NOT_FOUND));
     }
+
+    // 말더듬 분석 결과 저장
+    public void saveStutterDetail(long simulationId, String audioFileName) {
+
+        // 권한 확인
+        Long doctorId = jwtTokenProvider.getDoctorId();
+        Simulation simulation = getSimulation(simulationId);
+        if(doctorId != simulation.getPatient().getDoctor().getId()) {
+            throw new CustomException(ACCESS_DENIED);
+        }
+
+        // 말더듬 분석 요청 및 말더듬 결과 저장
+        webClient.post()
+                .uri("/stutter_model")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Collections.singletonMap("audio_name", audioFileName))
+                .retrieve()
+
+                // 말더듬 분석 결과가 없는 경우: 상태코드 204
+                .onStatus(status -> status.equals(HttpStatus.NO_CONTENT), response -> {
+                    log.info("말더듬 분석 결과 없음! status code: {}", response.statusCode().value());
+                    return Mono.empty();
+                })
+
+                // 예외 처리
+                .onStatus(status -> status.is4xxClientError(), response -> {
+                    return Mono.error(new CustomException(STUTTER_CLIENT_ERROR));
+                })
+                .onStatus(status -> status.is5xxServerError(), response -> {
+                    return Mono.error(new CustomException(STUTTER_SERVER_ERROR));
+                })
+
+                // 말더듬 분석 결과가 있는 경우
+                .bodyToMono(StutterDetailResponse.class)
+                .doOnNext(response -> {
+                    stutterDetailRepository.save(StutterDetail.create(simulation, response));
+                });
+
+    }
+
 }

--- a/src/main/java/com/talkpossible/project/global/config/WebClientConfig.java
+++ b/src/main/java/com/talkpossible/project/global/config/WebClientConfig.java
@@ -1,0 +1,17 @@
+package com.talkpossible.project.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(WebClient.Builder webClientBuilder) {
+        return webClientBuilder
+                .baseUrl("http://127.0.0.1:5000")
+                .build();
+    }
+
+}

--- a/src/main/java/com/talkpossible/project/global/exception/CustomErrorCode.java
+++ b/src/main/java/com/talkpossible/project/global/exception/CustomErrorCode.java
@@ -31,8 +31,14 @@ public enum CustomErrorCode {
     // Simulation (4xxx)
     SIMULATION_NOT_FOUND(NOT_FOUND, 4001, "해당하는 시뮬레이션 정보를 찾을 수 없습니다."),
 
-    // Patient(5xxx)
-    PATIENT_NOT_FOUND(NOT_FOUND, 5001, "해당하는 환자 정보를 찾을 수 없습니다.");
+    // Patient (5xxx)
+    PATIENT_NOT_FOUND(NOT_FOUND, 5001, "해당하는 환자 정보를 찾을 수 없습니다."),
+
+    // Voice Analysis (6xxx)
+    STUTTER_CLIENT_ERROR(BAD_REQUEST, 6001, "말더듬 분석 중 오류가 발생했습니다. (Client Error)"),
+    STUTTER_SERVER_ERROR(INTERNAL_SERVER_ERROR, 6002, "말더듬 분석 중 오류가 발생했습니다. (Server Error)"),
+    SPEECH_RATE_CLIENT_ERROR(BAD_REQUEST, 6003, "발화속도 측정 중 오류가 발생했습니다. (Client Error)"),
+    SPEECH_RATE_SERVER_ERROR(INTERNAL_SERVER_ERROR, 6004, "발화속도 측정 중 오류가 발생했습니다. (Server Error)");
 
     private final HttpStatus httpStatus;
     private final int code;


### PR DESCRIPTION
# 📄 Work Description
- 사용자 대화 내용 저장 & 말더듬 분석 API request dto 수정: content 외에 음성 파일명(vName) 항목 추가
- (시뮬레이션 중) 사용자 대화 내용 저장 & 말더듬 분석 API 호출 시, flask에서 말더듬 분석 스크립트를 실행하는 로직 추가
- (시뮬레이션 후) 발화속도 측정 API 호출 시, flask에서 발화속도 측정 스크립트를 실행하는 로직 추가

# ⚙️ ISSUE
- #53 


# 📷 Screenshot
- 발화속도 측정
![image](https://github.com/user-attachments/assets/b2d76145-f28e-4b36-96c5-a67da4aeefc5)
![image](https://github.com/user-attachments/assets/91e40524-1cda-4eec-b5bb-5511411610d8)

- 말더듬 분석
![image](https://github.com/user-attachments/assets/fd9d48b6-6a5e-4138-aed6-a866675a6d07)


# 💬 To Reviewers
- 현재 테스트 가능한 음성 파일은 말더듬 분석 내용이 없어, 파일이 추가되면 테스트 추가로 진행할 예정입니다!