### PR TITLE
[FEAT] 사용자 발화속도 db 저장 로직 구현

### DIFF
--- a/src/main/java/com/talkpossible/project/domain/domain/Simulation.java
+++ b/src/main/java/com/talkpossible/project/domain/domain/Simulation.java
@@ -34,7 +34,7 @@ public class Simulation extends BaseTimeEntity {
 
     private Time totalTime;
 
-    private int wordsPerMin;
+    private float wordsPerMin;
 
     private Boolean isStutter;
 
@@ -48,6 +48,10 @@ public class Simulation extends BaseTimeEntity {
         this.runDate = LocalDate.parse(runDate);
         this.totalTime = Time.valueOf(totalTime);
         this.videoUrl = videoUrl;
+    }
+
+    public void updateWordsPerMin(float wordsPerMin) {
+        this.wordsPerMin = wordsPerMin;
     }
 
 }

--- a/src/main/java/com/talkpossible/project/domain/service/SimulationService.java
+++ b/src/main/java/com/talkpossible/project/domain/service/SimulationService.java
@@ -34,6 +34,7 @@ import static com.talkpossible.project.global.exception.CustomErrorCode.*;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional(readOnly = true)
 public class SimulationService {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -106,7 +107,6 @@ public class SimulationService {
         return BasicInfoResponse.from(simulation, simulation.getPatient(), motionCount);
     }
 
-    @Transactional(readOnly = true)
     public UserMotionListResponse getMotionFeedback(final long simulationId) {
 
         Long doctorId = jwtTokenProvider.getDoctorId();
@@ -120,7 +120,6 @@ public class SimulationService {
 
     }
 
-    @Transactional(readOnly = true)
     public PatientSimulationListResponse getPatientSimulationInfo(final long patientId) {
 
         List<Simulation> patientSimulations = simulationRepository.findAllByPatientId(patientId);
@@ -148,6 +147,7 @@ public class SimulationService {
                 .orElseThrow(() -> new CustomException(PATIENT_NOT_FOUND));
     }
 
+    @Transactional
     // 발화속도 저장
     public void saveSpeechRate(long simulationId, SpeechRateRequest speechRateRequest) {
 
@@ -181,7 +181,7 @@ public class SimulationService {
                 .block();
         log.info("*** 발화속도 측정 결과: {}", wordsPerMin); // EX) 88.79
 
-        // TODO 응답값 저장 (Float이 반환되므로 Simulation 엔티티 wordsPerMin 필드 타입 변경 필요!)
+        simulation.updateWordsPerMin(wordsPerMin);
 
     }
 


### PR DESCRIPTION
# 📄 Work Description
- 사용자 발화속도 db 저장 로직 구현

# ⚙️ ISSUE
- closed #56 


# 📷 Screenshot
 - 동영상, 사진, 로그 등등
 - ex) 큐알 성공 이미지, 스웨거, 포스트맨 등


# 💬 To Reviewers
- Simulation 발화속도 필드가 기존 int에서 float 타입으로 수정되었습니다!
    `private float wordsPerMin;`
<br/>
- 더티체킹을 통해 발화속도 필드값을 수정하도록 했습니다
```java
    public void updateWordsPerMin(float wordsPerMin) {
        this.wordsPerMin = wordsPerMin;
    }
```

# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)
