### PR TITLE
[FIX] 비관적 락 적용을 통한 Simulation 엔티티의 동시성 문제 해결

### DIFF
--- a/src/main/java/com/talkpossible/project/domain/repository/SimulationRepository.java
+++ b/src/main/java/com/talkpossible/project/domain/repository/SimulationRepository.java
@@ -1,11 +1,21 @@
 package com.talkpossible.project.domain.repository;
 
 import com.talkpossible.project.domain.domain.Simulation;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SimulationRepository extends JpaRepository<Simulation, Long> {
 
     List<Simulation> findAllByPatientId(long patientdId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM Simulation s WHERE s.id = :id")
+    Optional<Simulation> findByIdWithLock(@Param("id") Long id);
+
 }

--- a/src/main/java/com/talkpossible/project/domain/service/MotionService.java
+++ b/src/main/java/com/talkpossible/project/domain/service/MotionService.java
@@ -7,11 +7,14 @@ import com.talkpossible.project.domain.dto.motion.request.UserMotionRequest;
 import com.talkpossible.project.domain.repository.MotionDetailRepository;
 import com.talkpossible.project.domain.repository.PatientRepository;
 import com.talkpossible.project.domain.repository.SimulationRepository;
+import com.talkpossible.project.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static com.talkpossible.project.global.exception.CustomErrorCode.SIMULATION_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -24,8 +27,11 @@ public class MotionService {
 
     @Transactional
     public void saveUserMotion(UserMotionRequest userMotionRequest) {
-        Simulation simulation = simulationRepository.findById(userMotionRequest.simulationId())
-                .orElseThrow(() -> new IllegalArgumentException("id에 해당하는 시뮬레이션 정보를 찾을 수 없습니다."));
+
+        //Simulation simulation = simulationRepository.findById(userMotionRequest.simulationId())
+        //        .orElseThrow(() -> new IllegalArgumentException("id에 해당하는 시뮬레이션 정보를 찾을 수 없습니다."));
+        Simulation simulation = simulationRepository.findByIdWithLock(userMotionRequest.simulationId())
+                .orElseThrow(() -> new CustomException(SIMULATION_NOT_FOUND));
 
         List<MotionDetail> motionDetails = userMotionRequest.motionList().stream().map(
                 motion -> MotionDetail.of(simulation, userMotionRequest, motion)).toList();

--- a/src/main/java/com/talkpossible/project/domain/service/SimulationService.java
+++ b/src/main/java/com/talkpossible/project/domain/service/SimulationService.java
@@ -143,7 +143,11 @@ public class SimulationService {
 
         // 권한 확인
         Long doctorId = jwtTokenProvider.getDoctorId();
-        Simulation simulation = getSimulation(simulationId);
+
+        //Simulation simulation = getSimulation(simulationId);
+        Simulation simulation = simulationRepository.findByIdWithLock(simulationId)
+                .orElseThrow(() -> new CustomException(SIMULATION_NOT_FOUND));
+
         if(doctorId != simulation.getPatient().getDoctor().getId()) {
             throw new CustomException(ACCESS_DENIED);
         }


### PR DESCRIPTION
# 📄 Work Description
- SimulationRepository에 @Lock 어노테이션을 사용하여 비관적 락 적용 
- 시뮬레이션 종료 후, 시뮬레이션 정보 및 발화 속도 업데이트 시 비관적 락 적용

# ⚙️ ISSUE
- closed #64 

<!--
# 📷 Screenshot
 - 동영상, 사진, 로그 등등
 - ex) 큐알 성공 이미지, 스웨거, 포스트맨 등


# 💬 To Reviewers
리뷰어들에게 하고 싶은 말


# 🔗 Reference
문제를 해결하면서 도움이 되었거나, 참고했던 사이트(코드링크)

-->